### PR TITLE
fix for flume MemoryTransaction errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ agent.sources.webserver.interceptors.intercepttime.type = timestamp
 ## Channels ########################################################
 agent.channels = memoryChannel
 agent.channels.memoryChannel.type = memory
-agent.channels.memoryChannel.capacity = 2000000
-
+agent.channels.memoryChannel.capacity = 1000
+agent.channels.memoryChannel.transactionCapacity = 1000
 
 ## Sinks ###########################################################
 


### PR DESCRIPTION
updated flume capacity has resolved the issue

No longer getting this

```
19 May 2015 20:41:26,048 ERROR [SinkRunner-PollingRunner-DefaultSinkProcessor] (org.apache.flume.SinkRunner$PollingRunner.run:160)  - Unable to deliver event. Exception follows.
org.apache.flume.EventDeliveryException: org.apache.flume.ChannelException: Take list for MemoryTransaction, capacity 100 full, consider committing more frequently, increasing capacity, or increasing thread count
        at org.apache.flume.sink.hive.HiveSink.process(HiveSink.java:375)
        at org.apache.flume.sink.DefaultSinkProcessor.process(DefaultSinkProcessor.java:68)
        at org.apache.flume.SinkRunner$PollingRunner.run(SinkRunner.java:147)
        at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.flume.ChannelException: Take list for MemoryTransaction, capacity 100 full, consider committing more frequently, increasing capacity, or increasing thread count
        at org.apache.flume.channel.MemoryChannel$MemoryTransaction.doTake(MemoryChannel.java:96)
        at org.apache.flume.channel.BasicTransactionSemantics.take(BasicTransactionSemantics.java:113)
        at org.apache.flume.channel.BasicChannelSemantics.take(BasicChannelSemantics.java:95)
        at org.apache.flume.sink.hive.HiveSink.drainOneBatch(HiveSink.java:392)
        at org.apache.flume.sink.hive.HiveSink.process(HiveSink.java:361)
        ... 3 more
...skipping...
    at org.apache.flume.sink.hive.HiveSink.drainOneBatch(HiveSink.java:392)
    at org.apache.flume.sink.hive.HiveSink.process(HiveSink.java:361)
    ... 3 more
```
